### PR TITLE
php5.3 compatibility

### DIFF
--- a/src/Ipunkt/LaravelNotifications/NotificationsServiceProvider.php
+++ b/src/Ipunkt/LaravelNotifications/NotificationsServiceProvider.php
@@ -28,10 +28,11 @@ class NotificationsServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('flash.notifications', function () {
+		$app = $this->app;
+		$this->app->bindShared('flash.notifications', function() use ($app) {
 
 			//	return an instance
-			return $this->app->make('Ipunkt\LaravelNotifications\FlashNotifier');
+			return $app->make('Ipunkt\LaravelNotifications\FlashNotifier');
 		});
 	}
 

--- a/src/lang/de/notifications.php
+++ b/src/lang/de/notifications.php
@@ -7,8 +7,8 @@
  */
 
 return array(
-	'modal' => [
+	'modal' => array(
 		'title' => 'Hinweis',
 		'close' => 'Schließen',
-	],
+	),
 );

--- a/src/lang/en/notifications.php
+++ b/src/lang/en/notifications.php
@@ -7,8 +7,8 @@
  */
 
 return array(
-	'modal' => [
+	'modal' => array(
 		'title' => 'Notice',
 		'close' => 'Close',
-	],
+	),
 );

--- a/src/views/bootstrap-3/flash.blade.php
+++ b/src/views/bootstrap-3/flash.blade.php
@@ -5,7 +5,7 @@ $showErrorSummary = false;
 
 $sources = array('success', 'errors', 'error', 'warning', 'info', 'notice');
 foreach ($sources as $source)
-	$messageSources[$source] = Session::get($source, []);
+	$messageSources[$source] = Session::get($source, array());
 
 $mapSourceToClass = array(
 	'success' => 'success',
@@ -18,23 +18,23 @@ $mapSourceToClass = array(
 
 ?>
 @if (isset($errors) && $errors->any() && $showErrorSummary)
-	@include('laravel-notifications::bootstrap-3/message', ['message' => 'Error occured', 'level' => 'danger', 'body' => 'Your last request got an error.'])
+	@include('laravel-notifications::bootstrap-3/message', array('message' => 'Error occured', 'level' => 'danger', 'body' => 'Your last request got an error.'))
 @endif
 
 @foreach ($messageSources as $source => $messages)
 	@if (is_array($messages))
 		@foreach ($messages as $message)
-			@include('laravel-notifications::bootstrap-3/message', ['message' => $message, 'level' => $mapSourceToClass[$source]])
+			@include('laravel-notifications::bootstrap-3/message', array('message' => $message, 'level' => $mapSourceToClass[$source]))
 		@endforeach
 	@else
-		@include('laravel-notifications::bootstrap-3/message', ['message' => $messages, 'level' => $mapSourceToClass[$source]])
+		@include('laravel-notifications::bootstrap-3/message', array('message' => $messages, 'level' => $mapSourceToClass[$source]))
 	@endif
 @endforeach
 
-@if (Session::has('flash_notification') && !empty(Session::get('flash_notification')))
+@if (Session::has('flash_notification') && count(Session::get('flash_notification')) > 0)
 	@if (Session::has('flash_notification.overlay'))
-		@include('laravel-notifications::bootstrap-3/modal', ['modalClass' => 'flash-modal', 'title' => Lang::get('laravel-notifications::notifications.modal.title'), 'body' => Session::get('flash_notification.message')])
+		@include('laravel-notifications::bootstrap-3/modal', array('modalClass' => 'flash-modal', 'title' => Lang::get('laravel-notifications::notifications.modal.title'), 'body' => Session::get('flash_notification.message')))
 	@else
-		@include('laravel-notifications::bootstrap-3/message', ['message' => Session::get('flash_notification.message'), 'level' => Session::get('flash_notification.level')])
+		@include('laravel-notifications::bootstrap-3/message', array('message' => Session::get('flash_notification.message'), 'level' => Session::get('flash_notification.level')))
 	@endif
 @endif


### PR DESCRIPTION
The [compser.json](https://github.com/ipunkt/laravel-notifications/blob/master/composer.json#L14) says php version is 5.3 or higher, so we need replace php5.4 or higher only syntax  to 5.3 compatibility.
